### PR TITLE
fix: @ducanh2912/next-pwa を transpilePackages に追加し iOS 12 の SyntaxError を修正

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -63,13 +63,9 @@ const withPWA = withPWAInit({
 });
 
 const nextConfig: NextConfig = {
-  /* config options here */
-  compiler: {
-    // iOS 12 (Safari 12) 対応のため、ES2019以前にトランスパイル
-    // Optional chaining (?.), Nullish coalescing (??) などをサポートしないブラウザに対応
-  },
   // レガシーブラウザサポートを有効化
-  transpilePackages: [],
+  // @ducanh2912/next-pwa を含めることで optional chaining (?.) 等を iOS 12 向けにトランスパイル
+  transpilePackages: ['@ducanh2912/next-pwa'],
 };
 
 export default withPWA(nextConfig);


### PR DESCRIPTION
## 問題

iOS 12.5.8 (Safari 12) で以下のエラーが残存していた（issue #8）：

```
[Error] SyntaxError: Unexpected token '.'
    （anonymous関数） (8928-874e652543876f58.js:1)
```

## 根本原因

`@ducanh2912/next-pwa` のクライアントサイドコードに Optional Chaining (`?.`) が含まれていたが、Next.js はデフォルトで `node_modules` をトランスパイルしないため、`.browserslistrc` の iOS >= 12 設定が適用されずそのまま出力されていた。

## 修正内容

`next.config.ts` の `transpilePackages` に `@ducanh2912/next-pwa` を追加。
これにより SWC が当該パッケージをトランスパイルし、`?.` が Safari 12 対応の構文に変換される。

## 確認結果

ビルド後の `8928` チャンク（next-pwa のコード）に `?.` が 0 件になったことを確認済み。

Closes #8